### PR TITLE
adding addLibertyMvnPlugin recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -139,7 +139,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name:  org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency
 displayName: Add Liberty Maven plugin dependencies
-description: This recipe adds required Open liberty plugin dependencies to the pom.xml file.
+description: This recipe adds  Open liberty plugin  to the pom.xml file.
 recipeList:
   - org.openrewrite.maven.AddPlugin:
       groupId: io.openliberty.tools

--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -138,8 +138,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name:  org.openrewrite.maven.liberty.AddOpenLibertyPlugin
-displayName: Add Liberty Maven plugin 
-description: This recipe adds  Open liberty plugin  to the pom.xml file.
+displayName: Add Liberty Maven plugin
+description: This recipe adds  Open liberty plugin to the pom.xml file.
 recipeList:
   - org.openrewrite.maven.AddPlugin:
       groupId: io.openliberty.tools

--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -141,7 +141,7 @@ name:  org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency
 displayName: Add Liberty Maven plugin dependencies
 description: This recipe adds required Open liberty plugin dependencies to the pom.xml file.
 recipeList:
-  - org.openrewrite.maven.AddDependency:
+  - org.openrewrite.maven.AddPlugin:
       groupId: io.openliberty.tools
       artifactId: liberty-maven-plugin
       version: 3.10.3

--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -139,7 +139,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name:  org.openrewrite.maven.liberty.AddOpenLibertyPlugin
 displayName: Add Liberty Maven plugin
-description: This recipe adds  Open liberty plugin to the pom.xml file.
+description: This recipe adds the Liberty Maven plugin, which provides several goals for managing a Liberty server and applications.
 recipeList:
   - org.openrewrite.maven.AddPlugin:
       groupId: io.openliberty.tools

--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -33,7 +33,7 @@ recipeList:
   - org.openrewrite.xml.liberty.PersistenceXmlLocationRule
   - org.openrewrite.xml.liberty.WebDDNamespaceRule
   - org.openrewrite.xml.liberty.DetectUnsupportedJSF
-  - org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency
+  - org.openrewrite.maven.liberty.AddOpenLibertyPlugin
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.liberty.WebSphereUnavailableSSOMethods
@@ -137,8 +137,8 @@ recipeList:
       searchAllNamespaces: false
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name:  org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency
-displayName: Add Liberty Maven plugin dependencies
+name:  org.openrewrite.maven.liberty.AddOpenLibertyPlugin
+displayName: Add Liberty Maven plugin 
 description: This recipe adds  Open liberty plugin  to the pom.xml file.
 recipeList:
   - org.openrewrite.maven.AddPlugin:

--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -33,6 +33,7 @@ recipeList:
   - org.openrewrite.xml.liberty.PersistenceXmlLocationRule
   - org.openrewrite.xml.liberty.WebDDNamespaceRule
   - org.openrewrite.xml.liberty.DetectUnsupportedJSF
+  - org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.liberty.WebSphereUnavailableSSOMethods
@@ -134,3 +135,13 @@ recipeList:
       newValue: http://xmlns.jcp.org/xml/ns/javaee
       versionMatcher: 3.1+
       searchAllNamespaces: false
+---
+type: specs.openrewrite.org/v1beta/recipe
+name:  org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency
+displayName: Add Liberty Maven plugin dependencies
+description: This recipe adds required Open liberty plugin dependencies to the pom.xml file.
+recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: io.openliberty.tools
+      artifactId: liberty-maven-plugin
+      version: 3.10.3

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -58,7 +58,7 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
                         <artifactId>my-app</artifactId>
                         <version>1</version>
                     </project>
-                """,
+                    """,
               """
                     <project>
                         <groupId>com.mycompany.app</groupId>
@@ -72,7 +72,7 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
                             </dependency>
                         </dependencies>
                     </project>
-                """
+                    """
             )
           )
         );
@@ -100,7 +100,7 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
                             </dependency>
                         </dependencies>
                     </project>
-                """
+                    """
             )
           )
         );

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -62,4 +62,32 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
           )
         );
     }
+    @Test
+    void testExistingLibertyPlugin() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
+          mavenProject(
+            "project",
+            srcMainJava(
+              java(sampleClass)
+            ),
+            pomXml(
+              """
+                     <project>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.openliberty.tools</groupId>
+                                <artifactId>liberty-maven-plugin</artifactId>
+                                <version>3.10.3</version>
+                            </dependency>
+                        </dependencies>
+                    </project>
+                """
+            )
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -43,7 +43,7 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
     }
 
     @Test
-    void testAddLibertyPlugin() {
+    void addLibertyPlugin() {
         rewriteRun(
           spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
           mavenProject(

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.maven.liberty;
 
 import org.intellij.lang.annotations.Language;

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -78,7 +78,7 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
         );
     }
     @Test
-    void testExistingLibertyPlugin() {
+    void existingLibertyPlugin() {
         rewriteRun(
           spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
           mavenProject(

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -53,26 +53,80 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
             ),
             pomXml(
               """
-                    <project>
-                        <groupId>com.mycompany.app</groupId>
-                        <artifactId>my-app</artifactId>
-                        <version>1</version>
-                    </project>
-                    """,
+                <?xml version="1.0" encoding="UTF-8" ?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.demo</groupId>
+                    <artifactId>app-name</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>war</packaging>
+                    <properties>
+                        <maven.compiler.source>21</maven.compiler.source>
+                        <maven.compiler.target>21</maven.compiler.target>
+                        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.eclipse.microprofile</groupId>
+                            <artifactId>microprofile</artifactId>
+                            <version>6.1</version>
+                            <type>pom</type>
+                            <scope>provided</scope>
+                        </dependency>
+                    </dependencies>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-war-plugin</artifactId>
+                                <version>3.3.2</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """,
               """
-                    <project>
-                        <groupId>com.mycompany.app</groupId>
-                        <artifactId>my-app</artifactId>
-                        <version>1</version>
-                        <dependencies>
-                            <dependency>
+                <?xml version="1.0" encoding="UTF-8" ?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.demo</groupId>
+                    <artifactId>app-name</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <packaging>war</packaging>
+                    <properties>
+                        <maven.compiler.source>21</maven.compiler.source>
+                        <maven.compiler.target>21</maven.compiler.target>
+                        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.eclipse.microprofile</groupId>
+                            <artifactId>microprofile</artifactId>
+                            <version>6.1</version>
+                            <type>pom</type>
+                            <scope>provided</scope>
+                        </dependency>
+                    </dependencies>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-war-plugin</artifactId>
+                                <version>3.3.2</version>
+                            </plugin>
+                            <plugin>
                                 <groupId>io.openliberty.tools</groupId>
                                 <artifactId>liberty-maven-plugin</artifactId>
                                 <version>3.10.3</version>
-                            </dependency>
-                        </dependencies>
-                    </project>
-                    """
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """
             )
           )
         );
@@ -87,20 +141,46 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
               java(sampleClass)
             ),
             pomXml(
-              """
-                     <project>
-                        <groupId>com.mycompany.app</groupId>
-                        <artifactId>my-app</artifactId>
-                        <version>1</version>
+                   """
+                   <?xml version="1.0" encoding="UTF-8" ?>
+                   <project xmlns="http://maven.apache.org/POM/4.0.0"
+                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                             xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.demo</groupId>
+                        <artifactId>app-name</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <packaging>war</packaging>
+                        <properties>
+                            <maven.compiler.source>21</maven.compiler.source>
+                            <maven.compiler.target>21</maven.compiler.target>
+                            <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                        </properties>
                         <dependencies>
                             <dependency>
-                                <groupId>io.openliberty.tools</groupId>
-                                <artifactId>liberty-maven-plugin</artifactId>
-                                <version>3.10.3</version>
+                                <groupId>org.eclipse.microprofile</groupId>
+                                <artifactId>microprofile</artifactId>
+                                <version>6.1</version>
+                                <type>pom</type>
+                                <scope>provided</scope>
                             </dependency>
                         </dependencies>
-                    </project>
-                    """
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <groupId>org.apache.maven.plugins</groupId>
+                                    <artifactId>maven-war-plugin</artifactId>
+                                    <version>3.3.2</version>
+                                </plugin>
+                                <plugin>
+                                    <groupId>io.openliberty.tools</groupId>
+                                    <artifactId>liberty-maven-plugin</artifactId>
+                                    <version>3.10.3</version>
+                                </plugin>
+                            </plugins>
+                        </build>
+                   </project>
+                   """
             )
           )
         );

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -1,0 +1,64 @@
+package org.openrewrite.maven.liberty;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+public class AddOpenLibertyPluginDependencyTest  implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion());
+    }
+
+    @Language("java")
+    private final String sampleClass = """
+         package com.test;
+
+         public class Test {         
+              public static void main(String[] args)
+              {
+                  System.out.println("test");
+               }
+         }     
+      """;
+    @Test
+    void testAddLibertyPlugin() {
+        rewriteRun(
+          spec ->  spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
+          mavenProject(
+            "project",
+            srcMainJava(
+              java(sampleClass)
+            ),
+            pomXml(
+              """
+                    <project>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                    </project>
+                """,
+              """
+                    <project>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.openliberty.tools</groupId>
+                                <artifactId>liberty-maven-plugin</artifactId>
+                                <version>3.10.3</version>
+                            </dependency>
+                        </dependencies>
+                    </project>
+                """
+            )
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginDependencyTest.java
@@ -9,12 +9,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-public class AddOpenLibertyPluginDependencyTest  implements RewriteTest {
-    @Override
-    public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion());
-    }
-
+class AddOpenLibertyPluginDependencyTest implements RewriteTest {
     @Language("java")
     private final String sampleClass = """
          package com.test;
@@ -26,10 +21,16 @@ public class AddOpenLibertyPluginDependencyTest  implements RewriteTest {
                }
          }     
       """;
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion());
+    }
+
     @Test
     void testAddLibertyPlugin() {
         rewriteRun(
-          spec ->  spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
+          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
           mavenProject(
             "project",
             srcMainJava(

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
@@ -192,6 +192,25 @@ class AddOpenLibertyPluginTest implements RewriteTest {
                         <maven.compiler.target>21</maven.compiler.target>
                         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                     </properties>
+                </project>
+                """,
+              """
+                <?xml version="1.0" encoding="UTF-8" ?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.demo</groupId>
+                    <artifactId>app-name</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <modules>
+                        <module>child</module>
+                    </modules>
+                    <properties>
+                        <maven.compiler.source>21</maven.compiler.source>
+                        <maven.compiler.target>21</maven.compiler.target>
+                        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                    </properties>
                     <build>
                         <plugins>
                             <plugin>
@@ -244,11 +263,51 @@ class AddOpenLibertyPluginTest implements RewriteTest {
                                   <artifactId>maven-war-plugin</artifactId>
                                   <version>3.3.2</version>
                               </plugin>
-                             <plugin>
-                                 <groupId>io.openliberty.tools</groupId>
-                                 <artifactId>liberty-maven-plugin</artifactId>
-                                 <version>3.10.3</version>
-                             </plugin>
+                          </plugins>
+                      </build>
+                  </project>
+                  """,
+                """
+                  <?xml version="1.0" encoding="UTF-8" ?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                          <groupId>com.demo</groupId>
+                          <artifactId>app-name</artifactId>
+                          <version>1.0-SNAPSHOT</version>
+                      </parent>
+                      <packaging>war</packaging>
+                      <modules>
+                          <module>child</module>
+                      </modules>
+                      <properties>
+                          <maven.compiler.source>21</maven.compiler.source>
+                          <maven.compiler.target>21</maven.compiler.target>
+                          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                      </properties>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.eclipse.microprofile</groupId>
+                              <artifactId>microprofile</artifactId>
+                              <version>6.1</version>
+                              <type>pom</type>
+                              <scope>provided</scope>
+                          </dependency>
+                      </dependencies>
+                      <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>org.apache.maven.plugins</groupId>
+                                  <artifactId>maven-war-plugin</artifactId>
+                                  <version>3.3.2</version>
+                              </plugin>
+                              <plugin>
+                                  <groupId>io.openliberty.tools</groupId>
+                                  <artifactId>liberty-maven-plugin</artifactId>
+                                  <version>3.10.3</version>
+                              </plugin>
                           </plugins>
                       </build>
                   </project>

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
@@ -15,27 +15,15 @@
  */
 package org.openrewrite.maven.liberty;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class AddOpenLibertyPluginTest implements RewriteTest {
-    @Language("java")
-    private final String sampleClass = """
-         package com.test;
-
-         public class Test {         
-              public static void main(String[] args)
-              {
-                  System.out.println("test");
-               }
-         }     
-      """;
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -46,11 +34,144 @@ class AddOpenLibertyPluginTest implements RewriteTest {
     void addLibertyPlugin() {
         rewriteRun(
           spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPlugin"),
+          //language=XML
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8" ?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.demo</groupId>
+                  <artifactId>app-name</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <packaging>war</packaging>
+                  <properties>
+                      <maven.compiler.source>21</maven.compiler.source>
+                      <maven.compiler.target>21</maven.compiler.target>
+                      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.eclipse.microprofile</groupId>
+                          <artifactId>microprofile</artifactId>
+                          <version>6.1</version>
+                          <type>pom</type>
+                          <scope>provided</scope>
+                      </dependency>
+                  </dependencies>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-war-plugin</artifactId>
+                              <version>3.3.2</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8" ?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.demo</groupId>
+                  <artifactId>app-name</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <packaging>war</packaging>
+                  <properties>
+                      <maven.compiler.source>21</maven.compiler.source>
+                      <maven.compiler.target>21</maven.compiler.target>
+                      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.eclipse.microprofile</groupId>
+                          <artifactId>microprofile</artifactId>
+                          <version>6.1</version>
+                          <type>pom</type>
+                          <scope>provided</scope>
+                      </dependency>
+                  </dependencies>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-war-plugin</artifactId>
+                              <version>3.3.2</version>
+                          </plugin>
+                          <plugin>
+                              <groupId>io.openliberty.tools</groupId>
+                              <artifactId>liberty-maven-plugin</artifactId>
+                              <version>3.10.3</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void existingLibertyPlugin() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPlugin"),
+          //language=XML
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8" ?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.demo</groupId>
+                  <artifactId>app-name</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <packaging>war</packaging>
+                  <properties>
+                      <maven.compiler.source>21</maven.compiler.source>
+                      <maven.compiler.target>21</maven.compiler.target>
+                      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.eclipse.microprofile</groupId>
+                          <artifactId>microprofile</artifactId>
+                          <version>6.1</version>
+                          <type>pom</type>
+                          <scope>provided</scope>
+                      </dependency>
+                  </dependencies>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-war-plugin</artifactId>
+                              <version>3.3.2</version>
+                          </plugin>
+                          <plugin>
+                              <groupId>io.openliberty.tools</groupId>
+                              <artifactId>liberty-maven-plugin</artifactId>
+                              <version>3.10.3</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void multiModuleProject() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPlugin"),
           mavenProject(
-            "project",
-            srcMainJava(
-              java(sampleClass)
-            ),
+            "parent",
+            //language=XML
             pomXml(
               """
                 <?xml version="1.0" encoding="UTF-8" ?>
@@ -61,63 +182,16 @@ class AddOpenLibertyPluginTest implements RewriteTest {
                     <groupId>com.demo</groupId>
                     <artifactId>app-name</artifactId>
                     <version>1.0-SNAPSHOT</version>
-                    <packaging>war</packaging>
+                    <modules>
+                        <module>child</module>
+                    </modules>
                     <properties>
                         <maven.compiler.source>21</maven.compiler.source>
                         <maven.compiler.target>21</maven.compiler.target>
                         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                     </properties>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.eclipse.microprofile</groupId>
-                            <artifactId>microprofile</artifactId>
-                            <version>6.1</version>
-                            <type>pom</type>
-                            <scope>provided</scope>
-                        </dependency>
-                    </dependencies>
                     <build>
                         <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-war-plugin</artifactId>
-                                <version>3.3.2</version>
-                            </plugin>
-                        </plugins>
-                    </build>
-                </project>
-                """,
-              """
-                <?xml version="1.0" encoding="UTF-8" ?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0"
-                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.demo</groupId>
-                    <artifactId>app-name</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                    <packaging>war</packaging>
-                    <properties>
-                        <maven.compiler.source>21</maven.compiler.source>
-                        <maven.compiler.target>21</maven.compiler.target>
-                        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                    </properties>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.eclipse.microprofile</groupId>
-                            <artifactId>microprofile</artifactId>
-                            <version>6.1</version>
-                            <type>pom</type>
-                            <scope>provided</scope>
-                        </dependency>
-                    </dependencies>
-                    <build>
-                        <plugins>
-                            <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-war-plugin</artifactId>
-                                <version>3.3.2</version>
-                            </plugin>
                             <plugin>
                                 <groupId>io.openliberty.tools</groupId>
                                 <artifactId>liberty-maven-plugin</artifactId>
@@ -127,60 +201,57 @@ class AddOpenLibertyPluginTest implements RewriteTest {
                     </build>
                 </project>
                 """
-            )
-          )
-        );
-    }
-    @Test
-    void existingLibertyPlugin() {
-        rewriteRun(
-          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPlugin"),
-          mavenProject(
-            "project",
-            srcMainJava(
-              java(sampleClass)
             ),
-            pomXml(
-                   """
-                   <?xml version="1.0" encoding="UTF-8" ?>
-                   <project xmlns="http://maven.apache.org/POM/4.0.0"
-                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                        <modelVersion>4.0.0</modelVersion>
-                        <groupId>com.demo</groupId>
-                        <artifactId>app-name</artifactId>
-                        <version>1.0-SNAPSHOT</version>
-                        <packaging>war</packaging>
-                        <properties>
-                            <maven.compiler.source>21</maven.compiler.source>
-                            <maven.compiler.target>21</maven.compiler.target>
-                            <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                        </properties>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.eclipse.microprofile</groupId>
-                                <artifactId>microprofile</artifactId>
-                                <version>6.1</version>
-                                <type>pom</type>
-                                <scope>provided</scope>
-                            </dependency>
-                        </dependencies>
-                        <build>
-                            <plugins>
-                                <plugin>
-                                    <groupId>org.apache.maven.plugins</groupId>
-                                    <artifactId>maven-war-plugin</artifactId>
-                                    <version>3.3.2</version>
-                                </plugin>
-                                <plugin>
-                                    <groupId>io.openliberty.tools</groupId>
-                                    <artifactId>liberty-maven-plugin</artifactId>
-                                    <version>3.10.3</version>
-                                </plugin>
-                            </plugins>
-                        </build>
-                   </project>
-                   """
+            mavenProject(
+              "child",
+              //language=XML
+              pomXml(
+                """
+                  <?xml version="1.0" encoding="UTF-8" ?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                          <groupId>com.demo</groupId>
+                          <artifactId>app-name</artifactId>
+                          <version>1.0-SNAPSHOT</version>
+                      </parent>
+                      <packaging>war</packaging>
+                      <modules>
+                          <module>child</module>
+                      </modules>
+                      <properties>
+                          <maven.compiler.source>21</maven.compiler.source>
+                          <maven.compiler.target>21</maven.compiler.target>
+                          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                      </properties>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.eclipse.microprofile</groupId>
+                              <artifactId>microprofile</artifactId>
+                              <version>6.1</version>
+                              <type>pom</type>
+                              <scope>provided</scope>
+                          </dependency>
+                      </dependencies>
+                      <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>org.apache.maven.plugins</groupId>
+                                  <artifactId>maven-war-plugin</artifactId>
+                                  <version>3.3.2</version>
+                              </plugin>
+                             <plugin>
+                                 <groupId>io.openliberty.tools</groupId>
+                                 <artifactId>liberty-maven-plugin</artifactId>
+                                 <version>3.10.3</version>
+                             </plugin>
+                          </plugins>
+                      </build>
+                  </project>
+                  """
+              )
             )
           )
         );

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
@@ -24,7 +24,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-class AddOpenLibertyPluginDependencyTest implements RewriteTest {
+class AddOpenLibertyPluginTest implements RewriteTest {
     @Language("java")
     private final String sampleClass = """
          package com.test;
@@ -45,7 +45,7 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
     @Test
     void addLibertyPlugin() {
         rewriteRun(
-          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
+          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPlugin"),
           mavenProject(
             "project",
             srcMainJava(
@@ -134,7 +134,7 @@ class AddOpenLibertyPluginDependencyTest implements RewriteTest {
     @Test
     void existingLibertyPlugin() {
         rewriteRun(
-          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency"),
+          spec -> spec.recipeFromResources("org.openrewrite.maven.liberty.AddOpenLibertyPlugin"),
           mavenProject(
             "project",
             srcMainJava(

--- a/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
+++ b/src/test/java/org/openrewrite/maven/liberty/AddOpenLibertyPluginTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.maven.liberty;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -30,6 +31,7 @@ class AddOpenLibertyPluginTest implements RewriteTest {
         spec.parser(JavaParser.fromJavaVersion());
     }
 
+    @DocumentExample
     @Test
     void addLibertyPlugin() {
         rewriteRun(


### PR DESCRIPTION
Recipe org.openrewrite.maven.liberty.AddOpenLibertyPluginDependency

## What's changed?
Simple recipe to update pom.xml to add OpenLibertyPluginDependency as part of **tWAS to Liberty General rule**


### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
