### PR TITLE
Add support for variables in RemoveWas2LibertyNonPortableJndiLookup recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
+++ b/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
@@ -24,6 +24,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.staticanalysis.RemoveUnusedLocalVariables;
+import org.openrewrite.staticanalysis.RemoveUnusedPrivateFields;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -109,6 +111,10 @@ public class RemoveWas2LibertyNonPortableJndiLookup extends ScanningRecipe<Set<J
                     // Return if the first argument is a variable and does not match the type of any collected variables
                     if (!acc.contains(((J.Identifier) firstArgument).getFieldType())) {
                         return mi;
+                    } else {
+                        // Remove the variable if this was the only use
+                        doAfterVisit(new RemoveUnusedLocalVariables(null, null).getVisitor());
+                        doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
                     }
                 }
 

--- a/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
+++ b/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
@@ -26,7 +26,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class RemoveWas2LibertyNonPortableJndiLookup extends ScanningRecipe<Set<JavaType.Variable>> {
@@ -102,9 +101,8 @@ public class RemoveWas2LibertyNonPortableJndiLookup extends ScanningRecipe<Set<J
                 Expression firstArgument = mi.getArguments().get(0);
                 if (firstArgument instanceof J.Literal) {
                     // Return if the first argument is a literal and does not match either property
-                    J.Literal literalExp = (J.Literal) firstArgument;
-                    Object value = literalExp.getValue();
-                    if (!value.equals(INITIAL_PROPERTY) && !value.equals(URL_PROPERTY)) {
+                    String stringValue = ((J.Literal) firstArgument).toString();
+                    if (!stringValue.equals(INITIAL_PROPERTY) && !stringValue.equals(URL_PROPERTY)) {
                         return mi;
                     }
                 } else if (firstArgument instanceof J.Identifier) {

--- a/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
+++ b/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
@@ -16,17 +16,22 @@
 package org.openrewrite.java.liberty;
 
 
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
+import org.openrewrite.ScanningRecipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.MethodCall;
+import org.openrewrite.java.tree.JavaType;
 
-public class RemoveWas2LibertyNonPortableJndiLookup extends Recipe {
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RemoveWas2LibertyNonPortableJndiLookup extends ScanningRecipe<Set<JavaType.Variable>> {
+    final private String INITIAL_PROPERTY = "java.naming.factory.initial";
+    final private String URL_PROPERTY = "java.naming.provider.url";
 
     @Override
     public String getDisplayName() {
@@ -39,45 +44,78 @@ public class RemoveWas2LibertyNonPortableJndiLookup extends Recipe {
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new MethodInvocationVisitor();
+    public Set<JavaType.Variable> getInitialValue(ExecutionContext ctx) {
+        return new HashSet<>();
     }
 
-    private class MethodInvocationVisitor extends JavaVisitor<ExecutionContext> {
-        MethodMatcher methodMatcher = new MethodMatcher("java.util.Hashtable put(java.lang.Object, java.lang.Object)", false);
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Set<JavaType.Variable> acc) {
 
-        @SuppressWarnings("NullableProblems")
-        @Override
-        public J.@Nullable MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-            return visitMethodCall(method);
-        }
+        return new JavaIsoVisitor<ExecutionContext>() {
 
-        private <M extends MethodCall> @Nullable M visitMethodCall(M methodCall) {
-            if (!methodMatcher.matches(methodCall)) {
-                return methodCall;
-            }
-            J.Block parentBlock = getCursor().firstEnclosing(J.Block.class);
-            //noinspection SuspiciousMethodCalls
-            if (parentBlock != null && !parentBlock.getStatements().contains(methodCall)) {
-                return methodCall;
-            }
-            // Remove the method invocation when the argumentMatcherPredicate is true for all arguments
-            Expression firstArg = methodCall.getArguments().get(0);
-            if (firstArg instanceof J.Literal) {
-                J.Literal literalExp = (J.Literal) firstArg;
-                Object value = literalExp.getValue();
-                if (!value.equals("java.naming.factory.initial") && !value.equals("java.naming.provider.url")) {
-                    return methodCall;
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations vd, ExecutionContext ctx) {
+                for (J.VariableDeclarations.NamedVariable variable : vd.getVariables()) {
+                    checkForPropertiesVariable(variable.getVariableType(), variable.getInitializer());
                 }
-            } else {
-                return methodCall;
+                return vd;
             }
 
-            if (methodCall.getMethodType() != null) {
-                maybeRemoveImport(methodCall.getMethodType().getDeclaringType());
+            @Override
+            public J.Assignment visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
+                JavaType.Variable variable = ((J.Identifier) assignment.getVariable()).getFieldType();
+                if (!checkForPropertiesVariable(variable, assignment.getAssignment())) {
+                    // If present, remove the variable from the accumulator since it was reassigned to an unrelated value
+                    acc.remove(variable);
+                }
+                return assignment;
             }
-            return null;
-        }
+
+            // Add a variable to the accumulator if it matches either property
+            private boolean checkForPropertiesVariable(JavaType.Variable variable, Expression value) {
+                if (value instanceof J.Literal) {
+                    String stringValue = ((J.Literal) value).toString();
+                    if (stringValue.equals(INITIAL_PROPERTY) || stringValue.equals(URL_PROPERTY)) {
+                        acc.add(variable);
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
     }
 
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Set<JavaType.Variable> acc) {
+        MethodMatcher methodMatcher = new MethodMatcher("java.util.Hashtable put(..)", false);
+
+
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+                // Return if this method does not match Hashtable.put()
+                if (!methodMatcher.matches(mi)) {
+                    return mi;
+                }
+
+                Expression firstArgument = mi.getArguments().get(0);
+                if (firstArgument instanceof J.Literal) {
+                    // Return if the first argument is a literal and does not match either property
+                    J.Literal literalExp = (J.Literal) firstArgument;
+                    Object value = literalExp.getValue();
+                    if (!value.equals(INITIAL_PROPERTY) && !value.equals(URL_PROPERTY)) {
+                        return mi;
+                    }
+                } else if (firstArgument instanceof J.Identifier) {
+                    // Return if the first argument is a variable and does not match the type of any collected variables
+                    if (!acc.contains(((J.Identifier) firstArgument).getFieldType())) {
+                        return mi;
+                    }
+                }
+
+                return null;
+            }
+        };
+    }
 }

--- a/src/test/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookupTest.java
+++ b/src/test/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookupTest.java
@@ -25,16 +25,15 @@ import static org.openrewrite.java.Assertions.java;
 
 class RemoveWas2LibertyNonPortableJndiLookupTest implements RewriteTest {
 
-  @Override
+    @Override
     public void defaults(RecipeSpec spec) {
-        spec
-          .recipe(new RemoveWas2LibertyNonPortableJndiLookup());
+        spec.recipe(new RemoveWas2LibertyNonPortableJndiLookup());
     }
 
 
     @DocumentExample
     @Test
-    void removeInvalidPropertiesTest() {
+    void literalTest() {
         rewriteRun(
           //language=java
           java(
@@ -45,11 +44,12 @@ class RemoveWas2LibertyNonPortableJndiLookupTest implements RewriteTest {
               import javax.naming.InitialContext;
 
               public class ServerNameUsage {
-                  
+
                   public void doX() {
                       Hashtable ht = new Hashtable();
                       ht.put("java.naming.factory.initial", "com.ibm.websphere.naming.WsnInitialContextFactory");
                       ht.put("java.naming.provider.url", "corbaloc:iiop:localhost:2809");
+                      ht.put("valid", "valid");
 
                       InitialContext ctx = new InitialContext(ht);
                   }
@@ -63,11 +63,248 @@ class RemoveWas2LibertyNonPortableJndiLookupTest implements RewriteTest {
               import javax.naming.InitialContext;
 
               public class ServerNameUsage {
-                  
+
                   public void doX() {
                       Hashtable ht = new Hashtable();
+                      ht.put("valid", "valid");
 
                       InitialContext ctx = new InitialContext(ht);
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      String initial = "java.naming.factory.initial";
+                      String url = "java.naming.provider.url";
+                      env.put(initial, "com.ibm.websphere.naming.WsnInitialContextFactory");
+                      env.put(url, "corbaloc:iiop:localhost:2809");
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """,
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      String initial = "java.naming.factory.initial";
+                      String url = "java.naming.provider.url";
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableAssignmentTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      String initial = "";
+                      String url = "";
+                      initial = "java.naming.factory.initial";
+                      url = "java.naming.provider.url";
+                      env.put(initial, "com.ibm.websphere.naming.WsnInitialContextFactory");
+                      env.put(url, "corbaloc:iiop:localhost:2809");
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """,
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      String initial = "";
+                      String url = "";
+                      initial = "java.naming.factory.initial";
+                      url = "java.naming.provider.url";
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableUnrelatedReassignmentTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      String initial = "java.naming.factory.initial";
+                      String url = "java.naming.provider.url";
+                      initial = "valid";
+                      url = "valid";
+                      env.put(initial, "com.ibm.websphere.naming.WsnInitialContextFactory");
+                      env.put(url, "corbaloc:iiop:localhost:2809");
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+                  private String initial = "java.naming.factory.initial";
+                  private String url = "java.naming.provider.url";
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      env.put(initial, "com.ibm.websphere.naming.WsnInitialContextFactory");
+                      env.put(url, "corbaloc:iiop:localhost:2809");
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """,
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+                  private String initial = "java.naming.factory.initial";
+                  private String url = "java.naming.provider.url";
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldReassignmentTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+                  private String initial = "";
+                  private String url = "";
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      initial = "java.naming.factory.initial";
+                      url = "java.naming.provider.url";
+                      env.put(initial, "com.ibm.websphere.naming.WsnInitialContextFactory");
+                      env.put(url, "corbaloc:iiop:localhost:2809");
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
+                  }
+
+              }
+              """,
+            """
+              package com.ibm;
+
+              import java.util.Hashtable;
+              import javax.naming.InitialContext;
+
+              public class ServerNameUsage {
+                  private String initial = "";
+                  private String url = "";
+
+                  public void doX() {
+                      Hashtable<String, String> env = new Hashtable<String, String>();
+                      initial = "java.naming.factory.initial";
+                      url = "java.naming.provider.url";
+                      env.put("valid", "valid");
+
+                      InitialContext ctx = new InitialContext(env);
                   }
 
               }

--- a/src/test/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookupTest.java
+++ b/src/test/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookupTest.java
@@ -113,8 +113,6 @@ class RemoveWas2LibertyNonPortableJndiLookupTest implements RewriteTest {
 
                   public void doX() {
                       Hashtable<String, String> env = new Hashtable<String, String>();
-                      String initial = "java.naming.factory.initial";
-                      String url = "java.naming.provider.url";
                       env.put("valid", "valid");
 
                       InitialContext ctx = new InitialContext(env);
@@ -164,10 +162,6 @@ class RemoveWas2LibertyNonPortableJndiLookupTest implements RewriteTest {
 
                   public void doX() {
                       Hashtable<String, String> env = new Hashtable<String, String>();
-                      String initial = "";
-                      String url = "";
-                      initial = "java.naming.factory.initial";
-                      url = "java.naming.provider.url";
                       env.put("valid", "valid");
 
                       InitialContext ctx = new InitialContext(env);
@@ -244,8 +238,6 @@ class RemoveWas2LibertyNonPortableJndiLookupTest implements RewriteTest {
               import javax.naming.InitialContext;
 
               public class ServerNameUsage {
-                  private String initial = "java.naming.factory.initial";
-                  private String url = "java.naming.provider.url";
 
                   public void doX() {
                       Hashtable<String, String> env = new Hashtable<String, String>();


### PR DESCRIPTION
## What's changed?
The `RemoveWas2LibertyNonPortableJndiLookup` recipe is intended to remove `Hashtable.put()` method invocations using the following WebSphere properties:
```
java.naming.factory.initial
java.naming.provider.url
```

Currently, this only works if these properties are specified in the method invocation as string literals. With this PR adds support for the case in which these parameters are passed into the method invocation as variables.

## What's your motivation?
The `RemoveWas2LibertyNonPortableJndiLookup` recipe will only remove method invocations using properties that are specified as string literals, but it would fail to remove method invocation using properties specifed using variables.

For example, this method invocation will be removed:
```
Hashtable ht = new Hashtable();
ht.put("java.naming.factory.initial", "");
```

But this method invocation will not to be removed:
```
String initial = "java.naming.factory.initial"

Hashtable ht = new Hashtable();
ht.put(initial, "");
```

The method invocation should be removed in both cases.

## Anyone you would like to review specifically?
@timtebeek
@cjobinabo

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
