### PR TITLE
Fix error in JNDI recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
+++ b/src/main/java/org/openrewrite/java/liberty/RemoveWas2LibertyNonPortableJndiLookup.java
@@ -58,14 +58,20 @@ public class RemoveWas2LibertyNonPortableJndiLookup extends ScanningRecipe<Set<J
             @Override
             public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations vd, ExecutionContext ctx) {
                 for (J.VariableDeclarations.NamedVariable variable : vd.getVariables()) {
-                    checkForPropertiesVariable(variable.getVariableType(), variable.getInitializer());
+                    Expression initializer = variable.getInitializer();
+                    if (initializer != null) {
+                        checkForPropertiesVariable(variable.getVariableType(), initializer);
+                    }
                 }
                 return vd;
             }
 
             @Override
             public J.Assignment visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
-                JavaType.Variable variable = ((J.Identifier) assignment.getVariable()).getFieldType();
+                Expression assignmentVariable = assignment.getVariable();
+                if (!(assignmentVariable instanceof J.Identifier)) return assignment;
+                J.Identifier assignmentVariableIdentifier = (J.Identifier) assignmentVariable;
+                JavaType.Variable variable = assignmentVariableIdentifier.getFieldType();
                 if (!checkForPropertiesVariable(variable, assignment.getAssignment())) {
                     // If present, remove the variable from the accumulator since it was reassigned to an unrelated value
                     acc.remove(variable);


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Fixes the following error encountered wile using the recipes:
```
java.lang.ClassCastException: class org.openrewrite.java.tree.J$ArrayAccess cannot be cast to class org.openrewrite.java.tree.J$Identifier (org.openrewrite.java.tree.J$ArrayAccess and org.openrewrite.java.tree.J$Identifier are in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @3593e074)
[ERROR]   org.openrewrite.java.liberty.RemoveWas2LibertyNonPortableJndiLookup$1.visitAssignment(RemoveWas2LibertyNonPortableJndiLookup.java:68)
[ERROR]   org.openrewrite.java.liberty.RemoveWas2LibertyNonPortableJndiLookup$1.visitAssignment(RemoveWas2LibertyNonPortableJndiLookup.java:56)
[ERROR]   org.openrewrite.java.tree.J$Assignment.acceptJava(J.java:499)
[ERROR]   org.openrewrite.java.tree.J.accept(J.java:59)
[ERROR]   org.openrewrite.TreeVisitor.visit(TreeVisitor.java:250)
[ERROR]   org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:320)
[ERROR]   org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1367)
[ERROR]   org.openrewrite.java.JavaVisitor.lambda$visitBlock$4(JavaVisitor.java:397)
[ERROR]   org.openrewrite.internal.ListUtils.map(ListUtils.java:177)
[ERROR]   org.openrewrite.java.JavaVisitor.visitBlock(JavaVisitor.java:396)
[ERROR]   org.openrewrite.java.JavaIsoVisitor.visitBlock(JavaIsoVisitor.java:88)
[ERROR]   org.openrewrite.java.JavaIsoVisitor.visitBlock(JavaIsoVisitor.java:30)
[ERROR]   org.openrewrite.java.tree.J$Block.acceptJava(J.java:838)
[ERROR]   org.openrewrite.java.tree.J.accept(J.java:59)
[ERROR]   org.openrewrite.TreeVisitor.visit(TreeVisitor.java:250)
[ERROR]   org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:320)
[ERROR]   ...
[ERROR] -> [Help 1]
```
