### PR TITLE
Adding recipe to replace WSPrincipal.getCredential()

### DIFF
--- a/src/main/java/org/openrewrite/java/liberty/ReplaceWSPrincipalGetCredential.java
+++ b/src/main/java/org/openrewrite/java/liberty/ReplaceWSPrincipalGetCredential.java
@@ -1,0 +1,112 @@
+package org.openrewrite.java.liberty;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.intellij.lang.annotations.Language;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.SourceFile;
+
+public class ReplaceWSPrincipalGetCredential extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Replace WSPrincipal.getCredential() implementation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace a public zero-arg `WSCredential getCredential()` with WSSubject.getCallerSubject() logic.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            private final JavaParser parser = JavaParser.fromJavaVersion().build();
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
+                md = super.visitMethodDeclaration(md, ctx);
+
+                if (!"getCredential".equals(md.getSimpleName())) {
+                    return md;
+                }
+
+                boolean isPublic = md.getModifiers().stream()
+                        .anyMatch(m -> m.getType().equals(J.Modifier.Type.Public));
+                if (!isPublic) {
+                    return md;
+                }
+
+                if (md.getReturnTypeExpression() == null) {
+                    return md;
+                }
+                String returnType = md.getReturnTypeExpression().printTrimmed();
+                if (!returnType.endsWith("WSCredential")) {
+                    return md;
+                }
+
+                @Language("java")
+                String dummy =
+                        "class Dummy {\n" +
+                                "    public com.ibm.websphere.security.cred.WSCredential getCredential() {\n" +
+                                "        com.ibm.websphere.security.cred.WSCredential credential = null;\n" +
+                                "        try {\n" +
+                                "            javax.security.auth.Subject subject =\n" +
+                                "                com.ibm.websphere.security.auth.WSSubject.getCallerSubject();\n" +
+                                "            if (subject != null) {\n" +
+                                "                credential = subject.getPublicCredentials(\n" +
+                                "                    com.ibm.websphere.security.cred.WSCredential.class\n" +
+                                "                ).iterator().next();\n" +
+                                "            }\n" +
+                                "        } catch (Exception e) {\n" +
+                                "            e.printStackTrace();\n" +
+                                "        }\n" +
+                                "        return credential;\n" +
+                                "    }\n" +
+                                "}";
+
+                List<SourceFile> parsed = parser.parse(dummy).collect(Collectors.toList());
+                J.Block newBody = null;
+                for (SourceFile sf : parsed) {
+                    if (!(sf instanceof J.CompilationUnit)) {
+                        continue;
+                    }
+                    J.CompilationUnit cu = (J.CompilationUnit) sf;
+                    for (J.ClassDeclaration cd : cu.getClasses()) {
+                        if (!"Dummy".equals(cd.getSimpleName())) {
+                            continue;
+                        }
+                        for (Object stmt : cd.getBody().getStatements()) {
+                            if (stmt instanceof J.MethodDeclaration) {
+                                J.MethodDeclaration dmd = (J.MethodDeclaration) stmt;
+                                if ("getCredential".equals(dmd.getSimpleName()) && dmd.getBody() != null) {
+                                    newBody = dmd.getBody();
+                                    break;
+                                }
+                            }
+                        }
+                        if (newBody != null) {
+                            break;
+                        }
+                    }
+                    if (newBody != null) {
+                        break;
+                    }
+                }
+                if (newBody == null) {
+                    return md;
+                }
+
+                return md.withBody(newBody);
+            }
+        };
+    }
+}

--- a/src/test/java/org/openrewrite/java/liberty/ReplaceWSPrincipalGetCredentialTest.java
+++ b/src/test/java/org/openrewrite/java/liberty/ReplaceWSPrincipalGetCredentialTest.java
@@ -1,0 +1,82 @@
+package org.openrewrite.java.liberty;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ReplaceWSPrincipalGetCredentialTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion())
+          .recipe(new ReplaceWSPrincipalGetCredential());
+    }
+
+    @Test
+    void replaceGetCredentialBodyWithoutStubs() {
+        // BEFORE: a legacy getCredential() returning a helper’s result
+        @Language("java")
+        String before = """
+            package com.example;
+
+            import com.ibm.websphere.security.auth.WSPrincipal;
+            import com.ibm.websphere.security.cred.WSCredential;
+
+            public class MyPrincipal implements WSPrincipal {
+                @Override
+                public WSCredential getCredential() {
+                    return fetchLegacyCredential();
+                }
+
+                private WSCredential fetchLegacyCredential() {
+                    return null;
+                }
+            }
+            """;
+
+        //  AFTER: same signature, but body replaced with WSSubject.getCallerSubject()
+        @Language("java")
+        String after = """
+            package com.example;
+
+            import com.ibm.websphere.security.auth.WSPrincipal;
+            import com.ibm.websphere.security.cred.WSCredential;
+
+            public class MyPrincipal implements WSPrincipal {
+                @Override
+                public WSCredential getCredential() {
+                    com.ibm.websphere.security.cred.WSCredential credential = null;
+                    try {
+                        javax.security.auth.Subject subject =
+                            com.ibm.websphere.security.auth.WSSubject.getCallerSubject();
+                        if (subject != null) {
+                            credential = subject.getPublicCredentials(
+                                com.ibm.websphere.security.cred.WSCredential.class
+                            ).iterator().next();
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    return credential;
+                }
+
+                private WSCredential fetchLegacyCredential() {
+                    return null;
+                }
+            }
+            """;
+
+        rewriteRun(
+          spec -> spec
+            .typeValidationOptions(TypeValidation.none())
+            .expectedCyclesThatMakeChanges(2),
+          java(before, after)
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added a new recipe ReplaceWSPrincipalGetCredential that automatically rewrites any public WSCredential getCredential() implementation in a WSPrincipal class to use WSSubject.getCallerSubject() for retrieving the WSCredential instead of legacy logic.

## Any additional context
I implemented  code for  com.ibm.websphere.security.auth.WSSubject.getCallerSubject()  instead of com.ibm.websphere.security.auth.WSPrincipal.getCredential()

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
