### PR TITLE
Remove invalid recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -34,7 +34,6 @@ recipeList:
   - org.openrewrite.xml.liberty.WebDDNamespaceRule
   - org.openrewrite.xml.liberty.DetectUnsupportedJSF
   - org.openrewrite.maven.liberty.AddOpenLibertyPlugin
-  - org.openrewrite.maven.liberty.WasDevMvnChangeParentArtifactId
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.liberty.WebSphereUnavailableSSOMethods


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Removed the `org.openrewrite.maven.liberty.WasDevMvnChangeParentArtifactId` recipe from the `MigrateFromWebSphereToLiberty` recipe list. The `WasDevMvnChangeParentArtifactId` recipe was removed from this repo in https://github.com/openrewrite/rewrite-liberty/pull/30.
