### PR TITLE
Remove declarative `WebBeansXmlRule` as imperative exists too

### DIFF
--- a/src/main/java/org/openrewrite/xml/liberty/WebBeansXmlRule.java
+++ b/src/main/java/org/openrewrite/xml/liberty/WebBeansXmlRule.java
@@ -71,10 +71,7 @@ public class WebBeansXmlRule extends Recipe {
 
                             if ("urn:java:ee".equalsIgnoreCase(xmlns)) {
 
-                                doAfterVisit(new ChangeTagName(
-                                        "WebBeans",
-                                        "beans"
-                                ).getVisitor());
+                                doAfterVisit(new ChangeTagName("WebBeans", "beans").getVisitor());
 
                                 doAfterVisit(new ChangeTagAttribute(
                                         "beans",
@@ -98,5 +95,4 @@ public class WebBeansXmlRule extends Recipe {
                 }
         );
     }
-
 }

--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -137,25 +137,6 @@ recipeList:
       searchAllNamespaces: false
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.xml.liberty.WebBeansXmlRule
-displayName: Replace OpenWebBeans schema in beans.xml
-description: The OpenWebBeans schema for beans.xml files is not supported in the Liberty CDI 1.2 implementation. This recipe updates beans.xml files using the OpenWebBeans schema to instead use the Weld implementation supported in Liberty CDI 1.2.
-recipeList:
-  - org.openrewrite.xml.ChangeTagName:
-      elementName: WebBeans
-      newTagName: beans
-  - org.openrewrite.xml.ChangeTagAttribute:
-      elementName: beans
-      attributeName: xmlns
-      newValue: http://xmlns.jcp.org/xml/ns/javaee
-  - org.openrewrite.xml.ChangeTagAttribute:
-      elementName: beans
-      attributeName: xsi:schemaLocation
-      newValue: >-
-        http://xmlns.jcp.org/xml/ns/javaee
-        http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd
----
-type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.maven.liberty.AddOpenLibertyPlugin
 displayName: Add Liberty Maven plugin
 description: This recipe adds the Liberty Maven plugin, which provides several goals for managing a Liberty server and applications.


### PR DESCRIPTION
There was a clash with having both an imperative and a declarative recipe of the exact same name, and with very similar functionality. I'm thinking that was a mistake in 
- https://github.com/openrewrite/rewrite-liberty/pull/27/files

We're seeing this pop up now as our docs only allow a single one of these two; Removing the declarative one as the imperative one has an additional conditional that I think was intended here.