### PR TITLE
Add missing recipe to MigrateFromWebSphereToLiberty

### DIFF
--- a/src/main/resources/META-INF/rewrite/was-to-liberty.yml
+++ b/src/main/resources/META-INF/rewrite/was-to-liberty.yml
@@ -25,6 +25,7 @@ description: >-
   from WebSphere Application Server traditional to Liberty.
 recipeList:
   - org.openrewrite.java.liberty.RemoveWas2LibertyNonPortableJndiLookup
+  - org.openrewrite.java.liberty.ReplaceWSPrincipalGetCredential
   - org.openrewrite.java.liberty.ServerName
   - org.openrewrite.java.liberty.WebSphereUnavailableSSOMethods
   - org.openrewrite.xml.liberty.AppDDNamespaceRule


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The `ReplaceWSPrincipalGetCredential` recipe was added to the `MigrateFromWebSphereToLiberty` recipe list.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
This is a WebSphere to Liberty migration recipe, and it should have been placed in the list initially.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
